### PR TITLE
Removed libcap related code

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ ENV PATH=/opt/rh/gcc-toolset-10/root/usr/bin:$PATH
 ARG VULKANVERSION
 RUN wget https://sdk.lunarg.com/sdk/download/${VULKANVERSION}/linux/vulkansdk-linux-x86_64-${VULKANVERSION}.tar.xz -O /tmp/vulkansdk-linux-x86_64-${VULKANVERSION}.tar.xz \
     && tar xvf /tmp/vulkansdk-linux-x86_64-${VULKANVERSION}.tar.xz \
-    && dnf -y install ninja-build libcap-devel \
+    && dnf -y install ninja-build \
     && ln -s /usr/bin/python3 /usr/bin/python \  
     && /${VULKANVERSION}/vulkansdk -j 8 vulkan-headers \
     && /${VULKANVERSION}/vulkansdk -j 8 shaderc
@@ -126,7 +126,7 @@ COPY --from=build /bin/ollama /bin/ollama
 
 FROM ubuntu:24.04
 RUN apt-get update \
-    && apt-get install -y ca-certificates libcap2 libvulkan1 \
+    && apt-get install -y ca-certificates libvulkan1 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 COPY --from=archive /bin /usr/bin

--- a/discover/gpu_info_vulkan.h
+++ b/discover/gpu_info_vulkan.h
@@ -4,28 +4,14 @@
 
 #include "gpu_info.h"
 
-#ifdef __linux__
-#include <sys/capability.h>
-#endif
-
 #include <vulkan/vulkan.h>
 
 typedef struct {
   void* vk_handle;
-  void* cap_handle;
   uint16_t verbose;
 
   VkInstance vk;
   int num_devices;
-
-#ifdef __linux__
-  cap_t (*cap_get_proc)(void);
-
-  int (*cap_get_bound)(cap_value_t);
-  int (*cap_set_flag)(cap_t, cap_flag_t, int, const cap_value_t *, cap_flag_value_t);
-  int (*cap_set_proc)(cap_t);
-  int (*cap_free)(cap_t);
-#endif
 
   void (*vkGetPhysicalDeviceProperties)(
     VkPhysicalDevice                            physicalDevice,
@@ -58,7 +44,7 @@ typedef struct vk_init_resp
   vk_handle_t ch;
 } vk_init_resp_t;
 
-void vk_init(char* vk_lib_path, char* cap_lib_path, vk_init_resp_t *resp);
+void vk_init(char* vk_lib_path, vk_init_resp_t *resp);
 void vk_check_vram(vk_handle_t rh, int i, mem_info_t *resp);
 int vk_check_flash_attention(vk_handle_t rh, int i);
 void vk_release(vk_handle_t rh);

--- a/discover/gpu_linux.go
+++ b/discover/gpu_linux.go
@@ -53,23 +53,12 @@ var (
 	NvmlMgmtName   = "" // not currently wired on linux
 	OneapiMgmtName = "libze_intel_gpu.so*"
 	VulkanMgmtName = "libvulkan.so*"
-	libcapMgmtName = "libcap.so*"
 )
 
 var VulkanGlobs = []string{
 	"/usr/lib/x86_64-linux-gnu/libvulkan.so*",
 	"/usr/lib/aarch64-linux-gnu/libvulkan.so*",
 	"/usr/lib*/libvulkan.so*",
-}
-
-var capLinuxGlobs = []string{
-	"/usr/lib/x86_64-linux-gnu/libcap.so*",
-	"/usr/lib/aarch64-linux-gnu/libvulkan.so*",
-	"/usr/lib*/libcap.so*",
-}
-
-func FindLibCapLibs() []string {
-	return FindGPULibs(libcapMgmtName, capLinuxGlobs)
 }
 
 func GetCPUMem() (memInfo, error) {


### PR DESCRIPTION
libcap is not directly related to Vulkan and should be added by its own PR. It adds additional library dependencies for building and also requires users to run setcap or run ollama as root, which is not ideal for easy use.

By removing libcap we can also fix an issue on Ubuntu where Intel iGPU is selected by default due to libcap using up some memory of dGPU.
 - https://github.com/ollama/ollama/pull/11835#issuecomment-3222759837